### PR TITLE
config: fix hardhat to listen to ip addresses

### DIFF
--- a/contracts/ethereum/hardhat.config.ts
+++ b/contracts/ethereum/hardhat.config.ts
@@ -30,7 +30,7 @@ const config: HardhatUserConfig = {
     },
     localhost: {
       type: "http",
-      url: "http://127.0.0.1:8545",
+      url: "http://0.0.0.0:8545",
       chainId: 31337,
       accounts: [
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; the only behavioral impact is which address the local Hardhat RPC endpoint is targeted at, which could affect connectivity in some dev environments.
> 
> **Overview**
> Updates Hardhat `localhost` network configuration to use `http://0.0.0.0:8545` instead of `http://127.0.0.1:8545`, allowing the local RPC endpoint to be reached via non-loopback interfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0022ae93b806054b27de646b03de85b9ccbfe34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->