### PR TITLE
fix: inject contract address into mobile env

### DIFF
--- a/contracts/ethereum/scripts/deploy.ts
+++ b/contracts/ethereum/scripts/deploy.ts
@@ -115,6 +115,27 @@ async function injectContractAddress(): Promise<void> {
         console.log('✅ Contract address injected into frontend .env.local');
         console.log(`🔗 Frontend will use contract: ${contractAddress}`);
 
+        const mobileEnvPath = join(process.cwd(), '..', '..', 'mobile', '.env');
+        let mobileEnvContent = '';
+        if (existsSync(mobileEnvPath)) {
+            mobileEnvContent = readFileSync(mobileEnvPath, 'utf8');
+        }
+        const mobileContractLine = `CONTRACT_ADDRESS=${contractAddress}`;
+        const mobileLines = mobileEnvContent.split('\n');
+        const mobileContractIdx = mobileLines.findIndex((line) =>
+            line.startsWith('CONTRACT_ADDRESS=')
+        );
+        if (mobileContractIdx >= 0) {
+            mobileLines[mobileContractIdx] = mobileContractLine;
+        } else {
+            mobileLines.push(mobileContractLine);
+        }
+        const mobileUpdated = mobileLines.filter((line) => line.trim()).join('\n');
+        writeFileSync(mobileEnvPath, mobileUpdated);
+
+        console.log('✅ Contract address injected into mobile .env');
+        console.log(`🔗 Mobile will use contract: ${contractAddress}`);
+
     } catch (error) {
         console.error('❌ Failed to inject contract address:', error instanceof Error ? error.message : 'Unknown error');
     }


### PR DESCRIPTION
#5 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to local deployment scripting that only writes the resolved contract address into `mobile/.env`, with minimal impact beyond developer workflow.
> 
> **Overview**
> After local deployment, the script now also updates `mobile/.env` with `CONTRACT_ADDRESS=<deployed address>` (upserting the key if it already exists), mirroring the existing frontend `.env.local` injection and logging the selected address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501351dc7848bab41ca6c4bcff43d9a014c47eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->